### PR TITLE
Fix constructor link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It also includes a repository and analysis of several [honeypots](honeypots/)
 - [Incorrect Interface](incorrect_interface/): Implementation uses different function signatures than interface
 - [Integer Overflow](integer_overflow/): Arithmetic in Solidity (or EVM) is not safe by default
 - [Forced Ether Reception](forced_ether_reception/): Contracts can be forced to receive Ether
-- [Missing Constructor](missing_constructor/): Anyone can become owner of contract due to missing constructor
+- [Wrong Constructor Name](wrong_constructor_name/): Anyone can become owner of contract due to missing constructor
 - [Race Condition](race_condition/): Transactions can be frontrun on the blockchain
 - [Reentrancy](reentrancy/): Calling external contracts gives them control over execution
 - [Unchecked External Call](unchecked_external_call/): Some Solidity operations silently fail

--- a/wrong_constructor_name/README.md
+++ b/wrong_constructor_name/README.md
@@ -12,4 +12,4 @@ As a result anyone can change the state variables initialized in this function.
 
 ## Examples
 - [Rubixi](Rubixi_source_code/Rubixi.sol) uses `DynamicPyramid` instead of `Rubixi` as a constructor
-- An [incorrectly named constructor](Missing.sol)
+- An [incorrectly named constructor](incorrect_constructor.sol)


### PR DESCRIPTION
Fixes some links to/in the Wrong Constructor folder that got broken in the recent rename